### PR TITLE
Base files for boot modules

### DIFF
--- a/.jshintignore
+++ b/.jshintignore
@@ -1,0 +1,2 @@
+node_modules
+coverage

--- a/.jshintrc
+++ b/.jshintrc
@@ -1,0 +1,16 @@
+{
+  "node": true,
+  "curly": false,
+  "quotmark": "single",
+  "maxcomplexity": 8,
+  "esnext": true,
+  "unused": true,
+  "globals": {
+    "after": true,
+    "afterEach": true,
+    "assert": true,
+    "before": true,
+    "beforeEach": true,
+    "describe": true
+  }
+}

--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,11 @@
+.git
+node_modules
+coverage
+test
+.sonar
+.gitignore
+.jshintignore
+.jshintrc
+.npmignore
+Makefile
+sonar-project.properties

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,27 @@
+.PHONY: test
+deps:
+	npm i -g jshint istanbul mocha
+	npm i
+lint:
+	jshint .
+test:
+	make lint
+	make cover
+init:
+	sed -i 's/{service-name}/$(NAME)/g' package.json
+	sed -i 's/{service-name}/$(NAME)/g' README.md
+	sed -i 's/{service-name}/$(NAME)/g' sonar-project.properties
+cover:
+	istanbul cover _mocha -- test --recursive --timeout=10000
+sonar:
+	sed '/sonar.projectVersion/d' ./sonar-project.properties > tmp && mv tmp sonar-project.properties
+	echo sonar.projectVersion=`cat package.json | python -c "import json,sys;obj=json.load(sys.stdin);print obj['version'];"` >> sonar-project.properties
+	wget http://repo1.maven.org/maven2/org/codehaus/sonar/runner/sonar-runner-dist/2.4/sonar-runner-dist-2.4.zip
+	unzip sonar-runner-dist-2.4.zip
+ifdef CI_PULL_REQUEST
+	@sonar-runner-2.4/bin/sonar-runner -e -Dsonar.analysis.mode=preview -Dsonar.github.pullRequest=${shell basename $(CI_PULL_REQUEST)} -Dsonar.github.repository=$(REPO_SLUG) -Dsonar.github.oauth=$(GITHUB_TOKEN) -Dsonar.login=$(SONAR_LOGIN) -Dsonar.password=$(SONAR_PASS) -Dsonar.host.url=$(SONAR_HOST_URL)
+endif
+ifeq ($(CIRCLE_BRANCH),develop)
+	@sonar-runner-2.4/bin/sonar-runner -e -Dsonar.analysis.mode=publish -Dsonar.host.url=$(SONAR_HOST_URL) -Dsonar.login=$(SONAR_LOGIN) -Dsonar.password=$(SONAR_PASS)
+endif
+	rm -rf sonar-runner-2.4 sonar-runner-dist-2.4.zip

--- a/README.md
+++ b/README.md
@@ -1,2 +1,28 @@
 # node-microservice-boot
-boot scripts to configure @dial-once node microservices
+
+[![Circle CI](https://circleci.com/gh/dial-once/node-microservice-boot/tree/develop.svg?style=shield)](https://circleci.com/gh/dial-once/node-microservice-boot)
+[![Coverage](http://badges.dialonce.io/?resource=node-microservice-boot&metrics=coverage)](http://sonar.dialonce.io/overview/coverage?id=node-microservice-boot)
+[![Sqale](http://badges.dialonce.io/?resource=node-microservice-boot&metrics=sqale_rating)](http://sonar.dialonce.io/overview/debt?id=node-microservice-boot)
+
+boot scripts to configure @dial-once node microservices  
+requires es6
+
+
+## Installing the module
+```bash
+npm i @dialonce/boot
+```
+
+## Using it
+Require it as the first instruction (after env vars are set)
+```js
+require('@dialonce/boot')({
+    LOGS_TOKEN: '',
+    BUGS_TOKEN: ''
+});
+```
+
+## Current included modules
+  - Bugsnag (bug reports)
+  - Logentries (logs)
+  - Winston (logs)

--- a/package.json
+++ b/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "@dialonce/boot",
+  "version": "0.0.0",
+  "description": "Dial Once's node microservice boot script",
+  "main": "src/index.js",
+  "directories": {
+    "test": "test"
+  },
+  "scripts": {
+    "test": "make test"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/dial-once/node-microservice-boot.git"
+  },
+  "author": "Dial Once",
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/dial-once/node-microservice-boot/issues"
+  },
+  "homepage": "https://github.com/dial-once/node-microservice-boot#readme",
+  "dependencies": {
+    "bugsnag": "^1.7.0",
+    "le_node": "^1.3.2",
+    "winston": "^2.2.0"
+  }
+}

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,11 @@
+sonar.projectKey=node-microservice-boot
+sonar.projectName=node-microservice-boot
+
+sonar.sources=src
+sonar.tests=test
+sonar.language=js
+sonar.profile=nodejs
+
+sonar.dynamicAnalysis=reuseReports
+sonar.javascript.jstest.reportsPath=coverage
+sonar.javascript.lcov.reportPath=coverage/lcov.info

--- a/src/bugsnag.js
+++ b/src/bugsnag.js
@@ -1,0 +1,6 @@
+module.exports = function(token) {
+  require('bugsnag').register(token, {
+    releaseStage: process.env.NODE_ENV || 'dev',
+    notifyReleaseStages: ['production', 'staging']
+  });
+};

--- a/src/env.js
+++ b/src/env.js
@@ -1,0 +1,17 @@
+const DEFAULT_INSTANCE_ID = 1;
+
+if (process.env.NODE_ENV === 'production') {
+  process.env.CONSOLE_LOGGING = 'false';
+}
+
+if (!process.env.HOSTNAME) {
+  process.env.HOSTNAME = process.env.USER;
+  process.env.INSTANCE_NUMBER = 0;
+} else {
+  //if this instance is workflow-1, the instance number is 0
+  var instanceNumber = process.env.HOSTNAME.split('-');
+  if (instanceNumber.length === 1) {
+    instanceNumber.push(DEFAULT_INSTANCE_ID);
+  }
+  process.env.INSTANCE_NUMBER = parseInt(instanceNumber[instanceNumber.length-1], 10);
+}

--- a/src/health.js
+++ b/src/health.js
@@ -1,0 +1,15 @@
+var winston = require('winston'),
+  startDate = new Date();
+
+/*
+ * Print health status every minute, and keep module alive
+ */
+module.exports = function() {
+  winston.info(process.env.HOSTNAME, {
+    status: 'running',
+    startedAt: startDate,
+    uptime: new Date().getTime() - startDate.getTime()
+  });
+};
+
+setInterval(module.exports, 60*1000);

--- a/src/index.js
+++ b/src/index.js
@@ -1,0 +1,11 @@
+require('./env');
+
+module.exports = function(config) {
+  config = Object.assign({}, config, {
+    BUGS_TOKEN: process.env.BUGSNAG_TOKEN,
+    LOGS_TOKEN: process.env.LOGENTRIES_TOKEN
+  });
+
+  require('./bugsnag')(config.BUGS_TOKEN);
+  require('./winston')(config.LOGS_TOKEN);
+};

--- a/src/winston.js
+++ b/src/winston.js
@@ -1,0 +1,30 @@
+/**
+ * winston module. Load winston and prepare transports to manage requests, for all further winston loading
+ * @module winston
+ */
+
+require('le_node');
+var winston = require('winston');
+
+module.exports = function(token) {
+  //we do not want console transport in production, because it reduce performances
+  if (process.env.CONSOLE_LOGGING === 'false') {
+    winston.remove(winston.transports.Console);
+  }
+
+  if (token) {
+    var logger = winston.add(winston.transports.Logentries, {
+      token: token
+    });
+
+    logger.rewriters.push(function(level, msg, meta) {
+      meta.instanceId = process.env.HOSTNAME;
+      return meta;
+    });
+
+    return logger;
+  }
+
+  return winston;
+};
+

--- a/test/bugsnag-spec.js
+++ b/test/bugsnag-spec.js
@@ -1,0 +1,22 @@
+var assert = require('assert'),
+  modulePath = '../src/bugsnag';
+
+describe('bugsnag', function() {
+
+  afterEach(function() {
+    delete require.cache[require.resolve(modulePath)];
+    process.env.NODE_ENV = '';
+  });
+
+  it('should set env to NODE_ENV', function() {
+    process.env.NODE_ENV = 'staging';
+    require(modulePath)();
+    assert(true);
+  });
+
+  it('should set env to dev', function() {
+    process.env.NODE_ENV = '';
+    require(modulePath)();
+    assert(true);
+  });
+});

--- a/test/entry-spec.js
+++ b/test/entry-spec.js
@@ -1,0 +1,7 @@
+
+describe('entry point', function() {
+  it('should load the entry point without error', function() {
+    require('../src/index');
+    return Promise.resolve();
+  });
+});

--- a/test/env-spec.js
+++ b/test/env-spec.js
@@ -1,0 +1,62 @@
+var assert = require('assert'),
+  modulePath = '../src/env';
+
+describe('env checks', function() {
+
+  var prevHostname = process.env.HOSTNAME,
+    prevUser = process.env.USER;
+
+  afterEach(function() {
+    delete require.cache[require.resolve(modulePath)];
+    process.env.HOSTNAME = prevHostname;
+    process.env.USER = prevUser;
+    process.env.CONSOLE_LOGGING = '';
+  });
+
+  beforeEach(function() {
+    delete require.cache[require.resolve(modulePath)];
+  });
+
+  it('should take USER env var if HOSTNAME is undefined', function() {
+    process.env.HOSTNAME = '';
+    process.env.USER = 'user';
+
+    require(modulePath);
+
+    assert.equal(process.env.HOSTNAME, 'user');
+  });
+
+  it('should NOT take USER env var if HOSTNAME is defined', function() {
+    process.env.HOSTNAME = 'test';
+    process.env.USER = 'user';
+
+    require(modulePath);
+
+    assert.equal(process.env.HOSTNAME, 'test');
+  });
+
+  it('should take instance ID if HOSTNAME is defined with docker cloud format', function() {
+    process.env.HOSTNAME = 'instance-3';
+
+    require(modulePath);
+
+    assert.equal(process.env.INSTANCE_NUMBER, '3');
+  });
+
+  it('should set CONSOLE_LOGGING to false if NODE_ENV is production', function() {
+    process.env.NODE_ENV = 'production';
+
+    require(modulePath);
+
+    assert.equal(process.env.CONSOLE_LOGGING, 'false');
+  });
+
+  it('should not set CONSOLE_LOGGING to false if NODE_ENV is not production', function() {
+    process.env.NODE_ENV = 'test';
+    process.env.CONSOLE_LOGGING = '';
+
+    require(modulePath);
+
+    assert.equal(process.env.CONSOLE_LOGGING, '');
+  });
+});

--- a/test/health-spec.js
+++ b/test/health-spec.js
@@ -1,0 +1,12 @@
+var assert = require('assert'),
+  health = require('../src/health');
+
+describe('health', function() {
+  it('should expose a function', function() {
+    assert.equal(typeof health, 'function');
+  });
+
+  it('should be able to call the function without throwing an error', function() {
+    health();
+  });
+});

--- a/test/index.js
+++ b/test/index.js
@@ -1,0 +1,15 @@
+var assert = require('assert');
+
+describe('entry point', function() {
+  it('should return a function', function() {
+    assert(typeof require('../src/index'), 'function');
+  });
+
+  it('should execute without an exception (no params)', function() {
+    require('../src/index')();
+  });
+
+  it('should execute without an exception (params)', function() {
+    require('../src/index')({});
+  });
+});

--- a/test/winston-spec.js
+++ b/test/winston-spec.js
@@ -1,0 +1,26 @@
+var assert = require('assert'),
+  modulePath = '../src/winston';
+
+describe('winston transports', function() {
+  beforeEach(function() {
+    process.env.CONSOLE_LOGGING = '';
+    delete require.cache[require.resolve(modulePath)];
+    delete require.cache[require.resolve('winston')];
+  });
+
+  it('should add logentries and console transports', function() {
+    var logger = require(modulePath)('cd9b3367-59d8-44c8-9d8e-096d79286bb4');
+
+    assert.equal(typeof logger.transports.logentries, 'object');
+    assert.equal(typeof logger.transports.console, 'object');
+
+    require('winston').info('it works');
+  });
+
+  it('should be able to disable console transport', function() {
+    process.env.CONSOLE_LOGGING = false;
+    var logger = require(modulePath)('');
+    assert.equal(typeof logger.transports.console, 'undefined');
+    require('winston').info('it works');
+  });
+});


### PR DESCRIPTION
Contains the boot modules loaded upon module start.

See README for more info:
https://github.com/dial-once/node-microservice-boot/tree/feature/basic-boot-scripts

With this module we should be able to just `require('@dialonce/boot')` on our microservices and it will configure common things (env vars, loggers, bugsnag init, etc.).

It have retro-compatibility on env vars (`LOGENTRIES_TOKEN`, `BUGSNAG_TOKEN`) but should be initiated like this:

```js
require('@dialonce/boot')({
    LOGS_TOKEN: '',
    BUGS_TOKEN: ''
});
```

This way, we will be able to change the underlying bug/log reporter and just rebuild each module, without having to change everything because env var name don't match the service name).

What do you think about it @mrister @jkernech @ky23 ?