### PR TITLE
Allow config to be skipped from parameters to get cached providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,16 @@ require('@dialonce/boot')({
 });
 ```
 
+## Using logger/reporter
+You can use the logger/reporter directly from the module, without including the deps in your project. This will allow us to update/switch providers easily.
+
+```js
+const logger = require('@dialonce/boot')().logger;
+const notifier = require('@dialonce/boot')().notifier;
+```
+
+*Please note that these instructions will print an error if the module has not been initialised before*
+
 ## Current included modules
   - Bugsnag (bug reports)
   - Logentries (logs)

--- a/src/index.js
+++ b/src/index.js
@@ -1,13 +1,44 @@
 require('./env');
+/**
+ * Starts with false, then is used to cache the internal providers
+ * @type {Boolean|Object}
+ */
+let initModule = false;
 
+/**
+ * Configure and return providers for our microservices. It should be required on module launch.
+ * It sets up loggers, notifiers for bugs, and exposes the internal providers, abstracted.
+ * If no parameter is provided, it will return already configured providers
+ * @param  {Object} [config] Configuration object required by the internal providers
+ * @param  {string} [config.BUGS_TOKEN] Token used by internal notifier to send bug reports to
+ * @param  {string} [config.LOGS_TOKEN] Token used by internal logger to send logs to
+ * @return {Object}        The configured providers
+ */
 module.exports = function(config) {
+  //if no param is provided, we want to return the cached modules
+  if (!config) {
+    //this should always be true when user require the module and have it initialised, else we print an error
+    if (initModule) {
+      return initModule;
+    } else {
+      console.error('Dial Once boot module should be initilised before used without config.');
+    }
+  }
+
+  /**
+   * Stores configuration with a fallback on old, deprecated env vars (BUGSNAG, LOGENTRIES)
+   * @type {Object}
+   */
   config = Object.assign({
     BUGS_TOKEN: process.env.BUGSNAG_TOKEN,
     LOGS_TOKEN: process.env.LOGENTRIES_TOKEN
   }, config);
 
-  return {
+  //stores the cached required modules for the next requires on @dialonce/boot
+  initModule = {
     notifier: require('./bugsnag')(config.BUGS_TOKEN),
     logger: require('./winston')(config.LOGS_TOKEN)
   };
+
+  return initModule;
 };

--- a/test/index.js
+++ b/test/index.js
@@ -1,11 +1,23 @@
 var assert = require('assert');
 
 describe('entry point', function() {
+  beforeEach(() => {
+    this.consoleKeep = console.error;
+  });
+
+  afterEach(() => {
+    console.error = this.consoleKeep;
+  });
+
   it('should return a function', function() {
     assert(typeof require('../src/index'), 'function');
   });
 
-  it('should execute without an exception (no params)', function() {
+  it('should execute without an exception (no params) but print a warning message', function(done) {
+    console.error = function(e) {
+      assert.equal(e, 'Dial Once boot module should be initilised before used without config.');
+      done();
+    };
     require('../src/index')();
   });
 
@@ -17,5 +29,19 @@ describe('entry point', function() {
     var index = require('../src/index')({});
     assert.notEqual(index.notifier, undefined);
     assert.notEqual(index.logger, undefined);
+  });
+
+  it('should return a logger and a notifier', function() {
+    var index = require('../src/index')({});
+    assert.notEqual(index.notifier, undefined);
+    assert.notEqual(index.logger, undefined);
+  });
+
+  it('should return a logger and a notifier (no params) without warning, already initialised', function(done) {
+    console.error = done;
+    var index = require('../src/index')();
+    assert.notEqual(index.notifier, undefined);
+    assert.notEqual(index.logger, undefined);
+    done();
   });
 });


### PR DESCRIPTION
@mrister: Following our discussion here https://github.com/dial-once/service-phone-number/pull/28#discussion-diff-70592049, allow require without params to get logger/notifier from anywhere in the code